### PR TITLE
Correct 01-intro.mkd image links

### DIFF
--- a/book3/01-intro.mkd
+++ b/book3/01-intro.mkd
@@ -19,7 +19,7 @@ assistants" who can take care of many things on our behalf. The hardware
 in our current-day computers is essentially built to continuously ask us
 the question, "What would you like me to do next?"
 
-![Personal Digital Assistant](height=1.0in@../images/pda)
+![Personal Digital Assistant](../images/pda.svg)
 
 Programmers add an operating system and a set of applications to the
 hardware and we end up with a Personal Digital Assistant that is quite
@@ -75,7 +75,7 @@ your choice.
 If we think of programs as the creative output of groups of programmers,
 perhaps the following figure is a more sensible version of our PDA:
 
-![Programmers Talking to You](height=1.0in@../images/pda2)
+![Programmers Talking to You](../images/pda2.svg)
 
 For now, our primary motivation is not to make money or please end
 users, but instead for us to be more productive in handling the data and
@@ -95,7 +95,7 @@ computers to develop software, we need to learn a small amount about how
 computers are built. If you were to take apart your computer or cell
 phone and look deep inside, you would find the following parts:
 
-![Hardware Architecture](height=1.75in@../images/arch)
+![Hardware Architecture](../images/arch.svg)
 
 The high-level definitions of these parts are as follows:
 
@@ -139,7 +139,7 @@ data you get from the solution. As a programmer you will mostly be
 tell the CPU to use the main memory, secondary memory, network, or the
 input/output devices.
 
-![Where Are You?](height=1.75in@../images/arch2)
+![Where Are You?](../images/arch2.svg)
 
 You need to be the person who answers the CPU's "What next?" question.
 But it would be very uncomfortable to shrink you down to 5mm tall and


### PR DESCRIPTION
This implementation of Markdown doesn't accept sizing attributes. Change to html img tags if needed.